### PR TITLE
[5220][FIX] Dockerfile: Switch back to odoo user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,3 +7,7 @@ USER root
 # Install Odoo Python dependencies (Custom)
 ADD requirements.txt /opt/custom_requirements.txt
 RUN pip install -r /opt/custom_requirements.txt
+
+# Switch back to running the Docker container as the odoo user,
+# because the odoo user properly owns the related Odoo log files.
+USER odoo


### PR DESCRIPTION
[5220](https://www.quartile.co/web#id=5525&menu_id=505&cids=3&action=1457&model=project.task&view_type=form)

Switch back to running the Docker container as the odoo user, because the odoo user properly owns the related Odoo log files.